### PR TITLE
Fix CI and makefile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.22
+image: golang:1.20
 
 .install_docker:
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,8 @@ image: golang:1.21
       wget -O docker-cli.deb https://download.docker.com/linux/debian/dists/bullseye/pool/stable/amd64/docker-ce-cli_20.10.18~3-0~debian-bullseye_amd64.deb && \
       dpkg -i docker-cli.deb && \
       rm docker-cli.deb
+    - go get github.com/golang/dep/cmd/dep
+    - dep ensure
 
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,8 +6,6 @@ image: golang:1.21
       wget -O docker-cli.deb https://download.docker.com/linux/debian/dists/bullseye/pool/stable/amd64/docker-ce-cli_20.10.18~3-0~debian-bullseye_amd64.deb && \
       dpkg -i docker-cli.deb && \
       rm docker-cli.deb
-    - go get github.com/golang/dep/cmd/dep
-    - $(go env GOPATH)/src/github.com/golang/dep ensure
 
 
 variables:
@@ -18,8 +16,6 @@ variables:
 .build_templatized_docker_image:
   before_script:
     - !reference [.install_docker, before_script]
-    # Turn on debug logging to output commands with vars to make local testing easier.
-    - set -x
     # Inject org & team names to conform to AIP naming conventions that make it possible to set
     # permissions and retention policies at each level.
     - IMAGE_REPOSITORY_PREFIX="${DOCKER_REPO_URL}/${ORGANIZATION_NAME}/${TEAM_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ image: golang:1.21
       dpkg -i docker-cli.deb && \
       rm docker-cli.deb
     - go get github.com/golang/dep/cmd/dep
-    - $GOPATH/bin/dep ensure
+    - $(go env GOPATH)/src/github.com/golang/dep ensure
 
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,6 @@ variables:
   TEAM_NAME: "ai-platform"
 .build_templatized_docker_image:
   before_script:
-    - !reference [.install_go, before_script]
     # Turn on debug logging to output commands with vars to make local testing easier.
     - set -x
     # Inject org & team names to conform to AIP naming conventions that make it possible to set

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,13 @@
 image: golang:1.22
 
-.install_go:
-  before_script:
-    - go get -u github.com/golang/dep/cmd/dep
-    - mkdir -p $GOPATH/src
-    - cd $GOPATH/src
-    - ln -s $CI_PROJECT_DIR
-    - cd $CI_PROJECT_NAME
-    - dep ensure  
+# .install_go:
+#   before_script:
+#     - go get -u github.com/golang/dep/cmd/dep
+#     - mkdir -p $GOPATH/src
+#     - cd $GOPATH/src
+#     - ln -s $CI_PROJECT_DIR
+#     - cd $CI_PROJECT_NAME
+#     - dep ensure
 
 variables:
   MAJOR_VERSION: "0"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+image: golang:1.22
+
+.install_go:
+  before_script:
+    - go get -u github.com/golang/dep/cmd/dep
+    - mkdir -p $GOPATH/src
+    - cd $GOPATH/src
+    - ln -s $CI_PROJECT_DIR
+    - cd $CI_PROJECT_NAME
+    - dep ensure  
+
 variables:
   MAJOR_VERSION: "0"
   MINOR_VERSION: "1"
@@ -5,6 +16,7 @@ variables:
   TEAM_NAME: "ai-platform"
 .build_templatized_docker_image:
   before_script:
+    - !reference [.install_go, before_script]
     # Turn on debug logging to output commands with vars to make local testing easier.
     - set -x
     # Inject org & team names to conform to AIP naming conventions that make it possible to set

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,6 @@ image: golang:1.21
       dpkg -i docker-cli.deb && \
       rm docker-cli.deb
 
-
 variables:
   MAJOR_VERSION: "0"
   MINOR_VERSION: "1"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.20
+image: golang:1.21
 
 .install_docker:
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,12 @@
 image: golang:1.22
 
-# .install_go:
-#   before_script:
-#     - go get -u github.com/golang/dep/cmd/dep
-#     - mkdir -p $GOPATH/src
-#     - cd $GOPATH/src
-#     - ln -s $CI_PROJECT_DIR
-#     - cd $CI_PROJECT_NAME
-#     - dep ensure
+.install_docker:
+  before_script:
+    - |
+      wget -O docker-cli.deb https://download.docker.com/linux/debian/dists/bullseye/pool/stable/amd64/docker-ce-cli_20.10.18~3-0~debian-bullseye_amd64.deb && \
+      dpkg -i docker-cli.deb && \
+      rm docker-cli.deb
+
 
 variables:
   MAJOR_VERSION: "0"
@@ -16,6 +15,7 @@ variables:
   TEAM_NAME: "ai-platform"
 .build_templatized_docker_image:
   before_script:
+    - !reference [.install_docker, before_script]
     # Turn on debug logging to output commands with vars to make local testing easier.
     - set -x
     # Inject org & team names to conform to AIP naming conventions that make it possible to set

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ image: golang:1.21
       dpkg -i docker-cli.deb && \
       rm docker-cli.deb
     - go get github.com/golang/dep/cmd/dep
-    - dep ensure
+    - $GOPATH/bin/dep ensure
 
 
 variables:

--- a/Makefile
+++ b/Makefile
@@ -46,17 +46,17 @@ K := $(foreach exec,$(EXECUTABLES), $(if $(shell which $(exec)),some string,$(er
 
 # build
 .PHONY: build
-build: dist/$(BINARY_NAME)-linux-amd64.gz dist/$(BINARY_NAME)-linux-arm64.gz dist/$(BINARY_NAME)-linux-arm.gz dist/$(BINARY_NAME)-linux-ppc64le.gz dist/$(BINARY_NAME)-linux-s390x.gz
+build: dist/$(BINARY_NAME)-linux-amd64.gz #dist/$(BINARY_NAME)-linux-arm64.gz dist/$(BINARY_NAME)-linux-arm.gz dist/$(BINARY_NAME)-linux-ppc64le.gz dist/$(BINARY_NAME)-linux-s390x.gz
 
 dist/$(BINARY_NAME)-%.gz: dist/$(BINARY_NAME)-%
 	@[ -e dist/$(BINARY_NAME)-$*.gz ] || gzip -k dist/$(BINARY_NAME)-$*
 
 dist/$(BINARY_NAME): GOARGS = GOOS= GOARCH=
 dist/$(BINARY_NAME)-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
-dist/$(BINARY_NAME)-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
-dist/$(BINARY_NAME)-linux-arm: GOARGS = GOOS=linux GOARCH=arm
-dist/$(BINARY_NAME)-linux-ppc64le: GOARGS = GOOS=linux GOARCH=ppc64le
-dist/$(BINARY_NAME)-linux-s390x: GOARGS = GOOS=linux GOARCH=s390x
+# dist/$(BINARY_NAME)-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
+# dist/$(BINARY_NAME)-linux-arm: GOARGS = GOOS=linux GOARCH=arm
+# dist/$(BINARY_NAME)-linux-ppc64le: GOARGS = GOOS=linux GOARCH=ppc64le
+# dist/$(BINARY_NAME)-linux-s390x: GOARGS = GOOS=linux GOARCH=s390x
 
 dist/$(BINARY_NAME):
 	go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/$(BINARY_NAME) ./cmd


### PR DESCRIPTION
Fixes the gitlab CI and reduces distribution images in the makefile to reduce build time as we only need the default amd64 image.