### PR TITLE
AIP-8603: Build new image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ variables:
   MINOR_VERSION: "1"
   ORGANIZATION_NAME: "artificial-intelligence"
   TEAM_NAME: "ai-platform"
+  ARGO_EVENTS_VERSION: "v1.9.2"
 .build_templatized_docker_image:
   before_script:
     - !reference [.install_docker, before_script]
@@ -19,7 +20,7 @@ variables:
     # permissions and retention policies at each level.
     - IMAGE_REPOSITORY_PREFIX="${DOCKER_REPO_URL}/${ORGANIZATION_NAME}/${TEAM_NAME}"
     # Ensure image tag is unique for each commit so we invalidate caching on machines pulling images.
-    - IMAGE_TAG="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
+    - IMAGE_TAG="${ARGO_EVENTS_VERSION}.${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
     # Actually set up the naming for the image we're currently building.
     - IMAGE_REPOSITORY="${IMAGE_REPOSITORY_PREFIX}/${ARTIFACT_NAME}"
     - IMAGE_REPOSITORY_TAG="${IMAGE_REPOSITORY}:${IMAGE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
     # permissions and retention policies at each level.
     - IMAGE_REPOSITORY_PREFIX="${DOCKER_REPO_URL}/${ORGANIZATION_NAME}/${TEAM_NAME}"
     # Ensure image tag is unique for each commit so we invalidate caching on machines pulling images.
-    - IMAGE_TAG="${ARGO_EVENTS_VERSION}.${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
+    - IMAGE_TAG="${ARGO_EVENTS_VERSION}-${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
     # Actually set up the naming for the image we're currently building.
     - IMAGE_REPOSITORY="${IMAGE_REPOSITORY_PREFIX}/${ARTIFACT_NAME}"
     - IMAGE_REPOSITORY_TAG="${IMAGE_REPOSITORY}:${IMAGE_TAG}"


### PR DESCRIPTION
Builds a new image with the argo events tag this build is based off of. Pulls in changes to shorten cloudevent ID and add retry exhaust metric.
