### PR TITLE
AIP-9757: Skip SQS Poll when Jetstream Eventbus is full

### DIFF
--- a/docs/eventsources/setup/aws-sqs.md
+++ b/docs/eventsources/setup/aws-sqs.md
@@ -95,6 +95,11 @@ spec:
       # Skip polling SQS when event bus is at capacity
       # Recommended: true (default: false)
       skipPollingWhenEventBusFull: true
+
+      # Wait duration (in seconds) between EventBus capacity checks when full
+      # Default: 10 seconds
+      # Optional: Configure to adjust check frequency based on your needs
+      eventBusFullWaitSeconds: 10
 ```
 
 **Benefits:**

--- a/docs/eventsources/setup/aws-sqs.md
+++ b/docs/eventsources/setup/aws-sqs.md
@@ -100,6 +100,11 @@ spec:
       # Default: 10 seconds
       # Optional: Configure to adjust check frequency based on your needs
       eventBusFullWaitSeconds: 10
+
+      # SQS batch size: number of messages to fetch per ReceiveMessage call
+      # Valid values: 1 to 10. Default: 10
+      # Optional
+      batchSize: 10
 ```
 
 **Benefits:**

--- a/docs/eventsources/setup/aws-sqs.md
+++ b/docs/eventsources/setup/aws-sqs.md
@@ -22,7 +22,7 @@ The structure of an event dispatched by the event-source over the eventbus looks
                  // see Amazon SQS Message Attributes
                  // (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html)
                  // in the Amazon Simple Queue Service Developer Guide.
-                 "messageAttributes": "message attributes", 
+                 "messageAttributes": "message attributes",
                    "body": "Body is the message data",
                 }
             }
@@ -31,11 +31,11 @@ The structure of an event dispatched by the event-source over the eventbus looks
 
 ## Setup
 
-1. Create a queue called `test` either using aws cli or AWS SQS management console.
+1.  Create a queue called `test` either using aws cli or AWS SQS management console.
 
-1. Fetch your access and secret key for AWS account and base64 encode them.
+1.  Fetch your access and secret key for AWS account and base64 encode them.
 
-1. Create a secret called `aws-secret` as follows.
+1.  Create a secret called `aws-secret` as follows.
 
         apiVersion: v1
         kind: Secret
@@ -46,25 +46,66 @@ The structure of an event dispatched by the event-source over the eventbus looks
           accesskey: <base64-access-key>
           secretkey: <base64-secret-key>
 
-1. Deploy the secret.
+1.  Deploy the secret.
 
         kubectl -n argo-events apply -f aws-secret.yaml
 
-1. Create the event source by running the following command.
+1.  Create the event source by running the following command.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/aws-sqs.yaml
 
-1. Inspect the event-source pod logs to make sure it was able to subscribe to the queue specified in the event source to consume messages.
+1.  Inspect the event-source pod logs to make sure it was able to subscribe to the queue specified in the event source to consume messages.
 
-1. Create the sensor by running the following command.
+1.  Create the sensor by running the following command.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/aws-sqs.yaml
 
-1. Dispatch a message on sqs queue.
+1.  Dispatch a message on sqs queue.
 
         aws sqs send-message --queue-url https://sqs.us-east-1.amazonaws.com/XXXXX/test --message-body '{"message": "hello"}'
 
-1. Once a message is published, an argo workflow will be triggered. Run `argo list` to find the workflow.
+1.  Once a message is published, an argo workflow will be triggered. Run `argo list` to find the workflow.
+
+## Configuration Options
+
+### Capacity-Based Polling Control
+
+The `skipPollingWhenEventBusFull` option enables intelligent backpressure handling to prevent message loss when the event bus is at capacity.
+
+**How it works:**
+
+- When enabled, the event source checks the JetStream event bus capacity before each SQS poll
+- If the event bus is full or unavailable, SQS polling is skipped
+- Messages remain in SQS with their visibility timeout intact
+- Polling automatically resumes when event bus capacity becomes available
+- Prevents SQS messages from being moved to DLQ due to event bus capacity issues
+
+**Configuration:**
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: aws-sqs
+spec:
+  sqs:
+    example:
+      # ... other configuration ...
+
+      # Skip polling SQS when event bus is at capacity
+      # Recommended: true (default: false)
+      skipPollingWhenEventBusFull: true
+```
+
+**Benefits:**
+
+- **Prevents message loss**: Messages stay in SQS when the event bus can't accept them
+- **Reduces API calls**: Avoids unnecessary SQS polling when downstream is saturated
+- **Self-healing**: Automatically resumes when capacity is available
+
+**Recommendations:**
+
+- Enable this option when using JetStream event bus with limited capacity
 
 ## Troubleshoot
 

--- a/docs/eventsources/setup/aws-sqs.md
+++ b/docs/eventsources/setup/aws-sqs.md
@@ -31,11 +31,11 @@ The structure of an event dispatched by the event-source over the eventbus looks
 
 ## Setup
 
-1.  Create a queue called `test` either using aws cli or AWS SQS management console.
+1. Create a queue called `test` either using aws cli or AWS SQS management console.
 
-1.  Fetch your access and secret key for AWS account and base64 encode them.
+1. Fetch your access and secret key for AWS account and base64 encode them.
 
-1.  Create a secret called `aws-secret` as follows.
+1. Create a secret called `aws-secret` as follows.
 
         apiVersion: v1
         kind: Secret
@@ -46,25 +46,25 @@ The structure of an event dispatched by the event-source over the eventbus looks
           accesskey: <base64-access-key>
           secretkey: <base64-secret-key>
 
-1.  Deploy the secret.
+1. Deploy the secret.
 
         kubectl -n argo-events apply -f aws-secret.yaml
 
-1.  Create the event source by running the following command.
+1. Create the event source by running the following command.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/aws-sqs.yaml
 
-1.  Inspect the event-source pod logs to make sure it was able to subscribe to the queue specified in the event source to consume messages.
+1. Inspect the event-source pod logs to make sure it was able to subscribe to the queue specified in the event source to consume messages.
 
-1.  Create the sensor by running the following command.
+1. Create the sensor by running the following command.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/aws-sqs.yaml
 
-1.  Dispatch a message on sqs queue.
+1. Dispatch a message on sqs queue.
 
         aws sqs send-message --queue-url https://sqs.us-east-1.amazonaws.com/XXXXX/test --message-body '{"message": "hello"}'
 
-1.  Once a message is published, an argo workflow will be triggered. Run `argo list` to find the workflow.
+1. Once a message is published, an argo workflow will be triggered. Run `argo list` to find the workflow.
 
 ## Configuration Options
 

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -20,6 +20,7 @@ import (
 	"github.com/argoproj/argo-events/common/logging"
 	"github.com/argoproj/argo-events/eventbus"
 	eventbuscommon "github.com/argoproj/argo-events/eventbus/common"
+	"github.com/argoproj/argo-events/eventbus/jetstream/eventsource"
 	eventsourcecommon "github.com/argoproj/argo-events/eventsources/common"
 	"github.com/argoproj/argo-events/eventsources/sources/amqp"
 	"github.com/argoproj/argo-events/eventsources/sources/awssns"
@@ -518,6 +519,17 @@ func (e *EventSourceAdaptor) run(ctx context.Context, servers map[apicommon.Even
 				// Continue starting other event services instead of failing all of them
 				continue
 			}
+			
+			// Set JetStream context for SQS event sources to enable capacity checking
+			if sqsServer, ok := server.(*awssqs.EventListener); ok {
+				if jetstreamConn, ok := e.eventBusConn.(*eventsource.JetstreamSourceConn); ok {
+					sqsServer.SetJetStreamContext(jetstreamConn.JSContext)
+					logger.Debugw("Set JetStream context for SQS event source",
+						zap.String("eventSource", server.GetEventSourceName()),
+						zap.String("eventName", server.GetEventName()))
+				}
+			}
+			
 			wg.Add(1)
 			go func(s EventingServer) {
 				defer wg.Done()

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -519,14 +519,14 @@ func (e *EventSourceAdaptor) run(ctx context.Context, servers map[apicommon.Even
 				continue
 			}
 			
-		// Set EventBus connection for SQS event sources to enable capacity checking
-		// The connection reference is automatically updated on reconnection
-		if sqsServer, ok := server.(*awssqs.EventListener); ok {
-			sqsServer.SetEventBusConnection(e.eventBusConn)
-			logger.Debugw("Set EventBus connection for SQS event source",
-				zap.String("eventSource", server.GetEventSourceName()),
-				zap.String("eventName", server.GetEventName()))
-		}
+			// Set EventBus connection for SQS event sources to enable capacity checking
+			// The connection reference is automatically updated on reconnection
+			if sqsServer, ok := server.(*awssqs.EventListener); ok {
+				sqsServer.SetEventBusConnection(e.eventBusConn)
+				logger.Debugw("Set EventBus connection for SQS event source",
+					zap.String("eventSource", server.GetEventSourceName()),
+					zap.String("eventName", server.GetEventName()))
+			}
 			
 			wg.Add(1)
 			go func(s EventingServer) {

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/argoproj/argo-events/common/logging"
 	"github.com/argoproj/argo-events/eventbus"
 	eventbuscommon "github.com/argoproj/argo-events/eventbus/common"
-	"github.com/argoproj/argo-events/eventbus/jetstream/eventsource"
 	eventsourcecommon "github.com/argoproj/argo-events/eventsources/common"
 	"github.com/argoproj/argo-events/eventsources/sources/amqp"
 	"github.com/argoproj/argo-events/eventsources/sources/awssns"
@@ -520,15 +519,14 @@ func (e *EventSourceAdaptor) run(ctx context.Context, servers map[apicommon.Even
 				continue
 			}
 			
-			// Set JetStream context for SQS event sources to enable capacity checking
-			if sqsServer, ok := server.(*awssqs.EventListener); ok {
-				if jetstreamConn, ok := e.eventBusConn.(*eventsource.JetstreamSourceConn); ok {
-					sqsServer.SetJetStreamContext(jetstreamConn.JSContext)
-					logger.Debugw("Set JetStream context for SQS event source",
-						zap.String("eventSource", server.GetEventSourceName()),
-						zap.String("eventName", server.GetEventName()))
-				}
-			}
+		// Set EventBus connection for SQS event sources to enable capacity checking
+		// The connection reference is automatically updated on reconnection
+		if sqsServer, ok := server.(*awssqs.EventListener); ok {
+			sqsServer.SetEventBusConnection(e.eventBusConn)
+			logger.Debugw("Set EventBus connection for SQS event source",
+				zap.String("eventSource", server.GetEventSourceName()),
+				zap.String("eventName", server.GetEventName()))
+		}
 			
 			wg.Add(1)
 			go func(s EventingServer) {

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -163,7 +163,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 		log.Info("Capacity-based polling control enabled - will check event bus capacity before each poll")
 	}
 
-	consecutiveFullChecks := 0
+	var eventBusFullStartTime *time.Time
 
 	for {
 		select {
@@ -179,16 +179,11 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 			if el.EventBusConn != nil && !el.EventBusConn.IsClosed() {
 				if _, ok := el.EventBusConn.(*eventsource.JetstreamSourceConn); ok {
 					if el.isEventBusFull(log) {
-						consecutiveFullChecks++
-
-						// Log warning every 10 minutes (60 checks * 10 seconds) when bus stays full
-						if consecutiveFullChecks%60 == 0 {
-							log.Warnw("EventBus has been full for extended period",
-								zap.String("eventSource", el.GetEventSourceName()),
-								zap.String("eventName", el.GetEventName()),
-								zap.Duration("duration", time.Duration(consecutiveFullChecks*10)*time.Second),
-								zap.Int("consecutiveChecks", consecutiveFullChecks))
-						} else {
+						// Track when EventBus becomes full
+						if eventBusFullStartTime == nil {
+							now := time.Now()
+							eventBusFullStartTime = &now
+							el.Metrics.SetEventBusFull(el.GetEventSourceName(), el.GetEventName(), true)
 							log.Infow("EventBus is full, skipping SQS poll",
 								zap.String("eventSource", el.GetEventSourceName()),
 								zap.String("eventName", el.GetEventName()))
@@ -198,13 +193,16 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 						continue
 					}
 
-					// Reset counter when capacity becomes available
-					if consecutiveFullChecks > 0 {
+					// EventBus capacity available - record duration if it was full
+					if eventBusFullStartTime != nil {
+						duration := time.Since(*eventBusFullStartTime)
+						el.Metrics.EventBusFullDuration(el.GetEventSourceName(), el.GetEventName(), duration.Seconds())
+						el.Metrics.SetEventBusFull(el.GetEventSourceName(), el.GetEventName(), false)
 						log.Infow("EventBus capacity available again, resuming SQS polling",
 							zap.String("eventSource", el.GetEventSourceName()),
 							zap.String("eventName", el.GetEventName()),
-							zap.Duration("wasFull", time.Duration(consecutiveFullChecks*10)*time.Second))
-						consecutiveFullChecks = 0
+							zap.Duration("wasFull", duration))
+						eventBusFullStartTime = nil
 					}
 				}
 			}

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	sqslib "github.com/aws/aws-sdk-go/service/sqs"
+	nats "github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 
 	"github.com/argoproj/argo-events/common/logging"
@@ -44,6 +45,8 @@ type EventListener struct {
 	EventName       string
 	SQSEventSource  v1alpha1.SQSEventSource
 	Metrics         *metrics.Metrics
+	// JetStream context for capacity checking (set during StartListening)
+	JSContext nats.JetStreamContext
 }
 
 // GetEventSourceName returns name of event source
@@ -59,6 +62,53 @@ func (el *EventListener) GetEventName() string {
 // GetEventSourceType return type of event server
 func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 	return apicommon.SQSEvent
+}
+
+// SetJetStreamContext sets the JetStream context for capacity checking
+func (el *EventListener) SetJetStreamContext(jsContext nats.JetStreamContext) {
+	el.JSContext = jsContext
+}
+
+// isEventBusFull checks if the event bus is at capacity or unavailable
+func (el *EventListener) isEventBusFull(log *zap.SugaredLogger) bool {
+	if el.JSContext == nil {
+		// If no JetStream context, treat as unavailable to prevent message loss
+		log.Warnw("JetStream context not available, treating as unavailable to prevent message loss",
+			zap.String("eventSource", el.GetEventSourceName()),
+			zap.String("eventName", el.GetEventName()))
+		return true
+	}
+
+	streamInfo, err := el.JSContext.StreamInfo("default")
+	if err != nil {
+		// If we can't check capacity, treat as unavailable to prevent message loss
+		log.Warnw("Failed to get stream info, treating as unavailable to prevent message loss",
+			zap.String("eventSource", el.GetEventSourceName()),
+			zap.String("eventName", el.GetEventName()),
+			zap.Error(err))
+		return true
+	}
+
+	// Check if stream is at capacity based on MaxMsgs
+	if streamInfo.Config.MaxMsgs > 0 && streamInfo.State.Msgs >= uint64(streamInfo.Config.MaxMsgs) {
+		log.Infow("EventBus at capacity - MaxMsgs limit reached",
+			zap.String("eventSource", el.GetEventSourceName()),
+			zap.String("eventName", el.GetEventName()),
+			zap.Uint64("currentMsgs", streamInfo.State.Msgs),
+			zap.Int64("maxMsgs", streamInfo.Config.MaxMsgs))
+		return true
+	}
+
+	// Event bus has available capacity
+	log.Debugw("EventBus has available capacity, proceeding with SQS poll",
+		zap.String("eventSource", el.GetEventSourceName()),
+		zap.String("eventName", el.GetEventName()),
+		zap.Uint64("currentMsgs", streamInfo.State.Msgs),
+		zap.Int64("maxMsgs", streamInfo.Config.MaxMsgs),
+		zap.Uint64("currentBytes", streamInfo.State.Bytes),
+		zap.Int64("maxBytes", streamInfo.Config.MaxBytes))
+
+	return false
 }
 
 // StartListening starts listening events
@@ -93,6 +143,14 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 	}
 
 	log.Info("listening for messages on the queue...")
+
+	// Log capacity-based polling control status
+	if sqsEventSource.SkipPollingWhenEventBusFull {
+		log.Info("Capacity-based polling control enabled - will check event bus capacity before each poll")
+	}
+
+	consecutiveFullChecks := 0
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -100,6 +158,39 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 			return nil
 		default:
 		}
+
+		// Check event bus capacity before polling if enabled
+		if sqsEventSource.SkipPollingWhenEventBusFull {
+			if el.isEventBusFull(log) {
+				consecutiveFullChecks++
+
+				// Log warning every 10 minutes (60 checks * 10 seconds) when bus stays full
+				if consecutiveFullChecks%60 == 0 {
+					log.Warnw("EventBus has been full for extended period",
+						zap.String("eventSource", el.GetEventSourceName()),
+						zap.String("eventName", el.GetEventName()),
+						zap.Duration("duration", time.Duration(consecutiveFullChecks*10)*time.Second),
+						zap.Int("consecutiveChecks", consecutiveFullChecks))
+				} else {
+					log.Infow("EventBus is full, skipping SQS poll",
+						zap.String("eventSource", el.GetEventSourceName()),
+						zap.String("eventName", el.GetEventName()))
+				}
+
+				time.Sleep(10 * time.Second) // Wait before checking capacity again
+				continue
+			}
+
+			// Reset counter when capacity becomes available
+			if consecutiveFullChecks > 0 {
+				log.Infow("EventBus capacity available again, resuming SQS polling",
+					zap.String("eventSource", el.GetEventSourceName()),
+					zap.String("eventName", el.GetEventName()),
+					zap.Duration("wasFull", time.Duration(consecutiveFullChecks*10)*time.Second))
+				consecutiveFullChecks = 0
+			}
+		}
+
 		messages, err := fetchMessages(ctx, sqsClient, *queueURL.QueueUrl, 10, sqsEventSource.WaitTimeSeconds)
 		if err != nil {
 			log.Errorw("failed to get messages from SQS", zap.Error(err))

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -212,7 +212,12 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 			}
 		}
 
-		messages, err := fetchMessages(ctx, sqsClient, *queueURL.QueueUrl, 10, sqsEventSource.WaitTimeSeconds)
+		batchSize := sqsEventSource.BatchSize
+		if batchSize <= 0 || batchSize > 10 {
+			batchSize = 10 // SQS maximum is 10
+		}
+
+		messages, err := fetchMessages(ctx, sqsClient, *queueURL.QueueUrl, batchSize, sqsEventSource.WaitTimeSeconds)
 		if err != nil {
 			log.Errorw("failed to get messages from SQS", zap.Error(err))
 			awsError, ok := err.(awserr.Error)

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -29,6 +29,7 @@ import (
 	nats "github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 
+	"github.com/argoproj/argo-events/common"
 	"github.com/argoproj/argo-events/common/logging"
 	eventsourcecommon "github.com/argoproj/argo-events/eventsources/common"
 	awscommon "github.com/argoproj/argo-events/eventsources/common/aws"
@@ -79,7 +80,7 @@ func (el *EventListener) isEventBusFull(log *zap.SugaredLogger) bool {
 		return true
 	}
 
-	streamInfo, err := el.JSContext.StreamInfo("default")
+	streamInfo, err := el.JSContext.StreamInfo(common.JetStreamStreamName)
 	if err != nil {
 		// If we can't check capacity, treat as unavailable to prevent message loss
 		log.Warnw("Failed to get stream info, treating as unavailable to prevent message loss",

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -26,11 +26,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	sqslib "github.com/aws/aws-sdk-go/service/sqs"
-	nats "github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 
 	"github.com/argoproj/argo-events/common"
 	"github.com/argoproj/argo-events/common/logging"
+	eventbuscommon "github.com/argoproj/argo-events/eventbus/common"
+	eventsource "github.com/argoproj/argo-events/eventbus/jetstream/eventsource"
 	eventsourcecommon "github.com/argoproj/argo-events/eventsources/common"
 	awscommon "github.com/argoproj/argo-events/eventsources/common/aws"
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -46,8 +47,9 @@ type EventListener struct {
 	EventName       string
 	SQSEventSource  v1alpha1.SQSEventSource
 	Metrics         *metrics.Metrics
-	// JetStream context for capacity checking (set during StartListening)
-	JSContext nats.JetStreamContext
+	// EventBus connection for capacity checking (set during initialization)
+	// Stores reference to the connection, which is automatically updated on reconnection
+	EventBusConn eventbuscommon.EventSourceConnection
 }
 
 // GetEventSourceName returns name of event source
@@ -65,22 +67,33 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 	return apicommon.SQSEvent
 }
 
-// SetJetStreamContext sets the JetStream context for capacity checking
-func (el *EventListener) SetJetStreamContext(jsContext nats.JetStreamContext) {
-	el.JSContext = jsContext
+// The connection reference is automatically updated on reconnection,
+// ensuring capacity checks always use the current active connection
+func (el *EventListener) SetEventBusConnection(conn eventbuscommon.EventSourceConnection) {
+	el.EventBusConn = conn
 }
 
 // isEventBusFull checks if the event bus is at capacity or unavailable
 func (el *EventListener) isEventBusFull(log *zap.SugaredLogger) bool {
-	if el.JSContext == nil {
-		// If no JetStream context, treat as unavailable to prevent message loss
-		log.Warnw("JetStream context not available, treating as unavailable to prevent message loss",
+	// Check if connection is available and active
+	if el.EventBusConn == nil || el.EventBusConn.IsClosed() {
+		log.Warnw("EventBus connection not available or closed, treating as unavailable to prevent message loss",
 			zap.String("eventSource", el.GetEventSourceName()),
 			zap.String("eventName", el.GetEventName()))
 		return true
 	}
 
-	streamInfo, err := el.JSContext.StreamInfo(common.JetStreamStreamName)
+	jetstreamConn := el.EventBusConn.(*eventsource.JetstreamSourceConn)
+
+	if jetstreamConn.JSContext == nil {
+		log.Warnw("JetStream context not initialized, treating as unavailable to prevent message loss",
+			zap.String("eventSource", el.GetEventSourceName()),
+			zap.String("eventName", el.GetEventName()))
+		return true
+	}
+
+	// Use the current connection's JSContext (automatically updated on reconnection)
+	streamInfo, err := jetstreamConn.JSContext.StreamInfo(common.JetStreamStreamName)
 	if err != nil {
 		// If we can't check capacity, treat as unavailable to prevent message loss
 		log.Warnw("Failed to get stream info, treating as unavailable to prevent message loss",
@@ -162,33 +175,38 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 
 		// Check event bus capacity before polling if enabled
 		if sqsEventSource.SkipPollingWhenEventBusFull {
-			if el.isEventBusFull(log) {
-				consecutiveFullChecks++
+			// Verify we have a JetStream connection before checking capacity
+			if el.EventBusConn != nil && !el.EventBusConn.IsClosed() {
+				if _, ok := el.EventBusConn.(*eventsource.JetstreamSourceConn); ok {
+					if el.isEventBusFull(log) {
+						consecutiveFullChecks++
 
-				// Log warning every 10 minutes (60 checks * 10 seconds) when bus stays full
-				if consecutiveFullChecks%60 == 0 {
-					log.Warnw("EventBus has been full for extended period",
-						zap.String("eventSource", el.GetEventSourceName()),
-						zap.String("eventName", el.GetEventName()),
-						zap.Duration("duration", time.Duration(consecutiveFullChecks*10)*time.Second),
-						zap.Int("consecutiveChecks", consecutiveFullChecks))
-				} else {
-					log.Infow("EventBus is full, skipping SQS poll",
-						zap.String("eventSource", el.GetEventSourceName()),
-						zap.String("eventName", el.GetEventName()))
+						// Log warning every 10 minutes (60 checks * 10 seconds) when bus stays full
+						if consecutiveFullChecks%60 == 0 {
+							log.Warnw("EventBus has been full for extended period",
+								zap.String("eventSource", el.GetEventSourceName()),
+								zap.String("eventName", el.GetEventName()),
+								zap.Duration("duration", time.Duration(consecutiveFullChecks*10)*time.Second),
+								zap.Int("consecutiveChecks", consecutiveFullChecks))
+						} else {
+							log.Infow("EventBus is full, skipping SQS poll",
+								zap.String("eventSource", el.GetEventSourceName()),
+								zap.String("eventName", el.GetEventName()))
+						}
+
+						time.Sleep(10 * time.Second) // Wait before checking capacity again
+						continue
+					}
+
+					// Reset counter when capacity becomes available
+					if consecutiveFullChecks > 0 {
+						log.Infow("EventBus capacity available again, resuming SQS polling",
+							zap.String("eventSource", el.GetEventSourceName()),
+							zap.String("eventName", el.GetEventName()),
+							zap.Duration("wasFull", time.Duration(consecutiveFullChecks*10)*time.Second))
+						consecutiveFullChecks = 0
+					}
 				}
-
-				time.Sleep(10 * time.Second) // Wait before checking capacity again
-				continue
-			}
-
-			// Reset counter when capacity becomes available
-			if consecutiveFullChecks > 0 {
-				log.Infow("EventBus capacity available again, resuming SQS polling",
-					zap.String("eventSource", el.GetEventSourceName()),
-					zap.String("eventName", el.GetEventName()),
-					zap.Duration("wasFull", time.Duration(consecutiveFullChecks*10)*time.Second))
-				consecutiveFullChecks = 0
 			}
 		}
 

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -189,7 +189,11 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 								zap.String("eventName", el.GetEventName()))
 						}
 
-						time.Sleep(10 * time.Second) // Wait before checking capacity again
+						waitSeconds := sqsEventSource.EventBusFullWaitSeconds
+						if waitSeconds <= 0 {
+							waitSeconds = 10
+						}
+						time.Sleep(time.Duration(waitSeconds) * time.Second)
 						continue
 					}
 

--- a/examples/event-sources/aws-sqs.yaml
+++ b/examples/event-sources/aws-sqs.yaml
@@ -27,6 +27,14 @@ spec:
       # The duration (in seconds) for which the call waits for a message to arrive in the queue before returning.
       # MUST BE > 0 AND <= 20
       waitTimeSeconds: 20
+      
+      # CAPACITY-BASED POLLING CONTROL
+      # Skip polling SQS when event bus is at capacity to prevent backpressure
+      # When enabled, the event source will check event bus capacity before each
+      # poll attempt and skip polling when the event bus is full, reducing API
+      # calls and preventing message accumulation when downstream processing is slow.
+      # +optional
+      skipPollingWhenEventBusFull: true
 
 #    example-without-credentials:
 #      # If AWS access credentials are already present on the Pod's IAM role running the EventSource,

--- a/examples/event-sources/aws-sqs.yaml
+++ b/examples/event-sources/aws-sqs.yaml
@@ -27,6 +27,10 @@ spec:
       # The duration (in seconds) for which the call waits for a message to arrive in the queue before returning.
       # MUST BE > 0 AND <= 20
       waitTimeSeconds: 20
+      # The number of messages to fetch per SQS ReceiveMessage call (batch size).
+      # Valid values: 1 to 10. Defaults to 10 if not specified.
+      # +optional
+      batchSize: 10
       
       # CAPACITY-BASED POLLING CONTROL
       # Skip polling SQS when event bus is at capacity

--- a/examples/event-sources/aws-sqs.yaml
+++ b/examples/event-sources/aws-sqs.yaml
@@ -29,7 +29,7 @@ spec:
       waitTimeSeconds: 20
       
       # CAPACITY-BASED POLLING CONTROL
-      # Skip polling SQS when event bus is at capacity to prevent backpressure
+      # Skip polling SQS when event bus is at capacity
       # When enabled, the event source will check event bus capacity before each
       # poll attempt and skip polling when the event bus is full, reducing API
       # calls and preventing message accumulation when downstream processing is slow.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -43,6 +43,8 @@ type Metrics struct {
 	eventsSentFailed        *prometheus.CounterVec
 	eventsProcessingFailed  *prometheus.CounterVec
 	eventProcessingDuration *prometheus.SummaryVec
+	eventBusFullDuration    *prometheus.SummaryVec
+	eventBusFull            *prometheus.GaugeVec
 	actionTriggered         *prometheus.CounterVec
 	actionFailed            *prometheus.CounterVec
 	actionRetriesFailed     *prometheus.CounterVec
@@ -93,6 +95,22 @@ func NewMetrics(namespace string) *Metrics {
 				labelNamespace: namespace,
 			},
 		}, []string{labelEventSourceName, labelEventName}),
+		eventBusFullDuration: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace: prefix,
+			Name:      "eventbus_full_duration_seconds",
+			Help:      "Summary of durations (in seconds) that the EventBus was at capacity and SQS polling was skipped. https://argoproj.github.io/argo-events/metrics/#argo_events_eventbus_full_duration_seconds",
+			ConstLabels: prometheus.Labels{
+				labelNamespace: namespace,
+			},
+		}, []string{labelEventSourceName, labelEventName}),
+		eventBusFull: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: prefix,
+			Name:      "eventbus_full",
+			Help:      "Current state of EventBus capacity: 1 if full, 0 if available. Used for alerting when EventBus is full for extended periods. https://argoproj.github.io/argo-events/metrics/#argo_events_eventbus_full",
+			ConstLabels: prometheus.Labels{
+				labelNamespace: namespace,
+			},
+		}, []string{labelEventSourceName, labelEventName}),
 		actionTriggered: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: prefix,
 			Name:      "action_triggered_total",
@@ -134,6 +152,8 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.eventsSentFailed.Collect(ch)
 	m.eventsProcessingFailed.Collect(ch)
 	m.eventProcessingDuration.Collect(ch)
+	m.eventBusFullDuration.Collect(ch)
+	m.eventBusFull.Collect(ch)
 	m.actionTriggered.Collect(ch)
 	m.actionFailed.Collect(ch)
 	m.actionRetriesFailed.Collect(ch)
@@ -146,6 +166,8 @@ func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	m.eventsSentFailed.Describe(ch)
 	m.eventsProcessingFailed.Describe(ch)
 	m.eventProcessingDuration.Describe(ch)
+	m.eventBusFullDuration.Describe(ch)
+	m.eventBusFull.Describe(ch)
 	m.actionTriggered.Describe(ch)
 	m.actionFailed.Describe(ch)
 	m.actionRetriesFailed.Describe(ch)
@@ -174,6 +196,18 @@ func (m *Metrics) EventProcessingFailed(eventSourceName, eventName string) {
 
 func (m *Metrics) EventProcessingDuration(eventSourceName, eventName string, num float64) {
 	m.eventProcessingDuration.WithLabelValues(eventSourceName, eventName).Observe(num)
+}
+
+func (m *Metrics) EventBusFullDuration(eventSourceName, eventName string, durationSeconds float64) {
+	m.eventBusFullDuration.WithLabelValues(eventSourceName, eventName).Observe(durationSeconds)
+}
+
+func (m *Metrics) SetEventBusFull(eventSourceName, eventName string, isFull bool) {
+	if isFull {
+		m.eventBusFull.WithLabelValues(eventSourceName, eventName).Set(1)
+	} else {
+		m.eventBusFull.WithLabelValues(eventSourceName, eventName).Set(0)
+	}
 }
 
 func (m *Metrics) ActionTriggered(sensorName, triggerName string) {

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -722,6 +722,9 @@ type SQSEventSource struct {
 	// SessionToken refers to K8s secret containing AWS temporary credentials(STS) session token
 	// +optional
 	SessionToken *corev1.SecretKeySelector `json:"sessionToken,omitempty" protobuf:"bytes,13,opt,name=sessionToken"`
+	// SkipPollingWhenEventBusFull skips polling SQS when event bus is at capacity
+	// +optional
+	SkipPollingWhenEventBusFull bool `json:"skipPollingWhenEventBusFull,omitempty" protobuf:"varint,14,opt,name=skipPollingWhenEventBusFull"`
 }
 
 // PubSubEventSource refers to event-source for GCP PubSub related events.

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -729,6 +729,10 @@ type SQSEventSource struct {
 	// The default value is 10 seconds.
 	// +optional
 	EventBusFullWaitSeconds int64 `json:"eventBusFullWaitSeconds,omitempty" protobuf:"varint,15,opt,name=eventBusFullWaitSeconds"`
+	// BatchSize is the number of messages to fetch per SQS ReceiveMessage call (SQS batch size).
+	// Valid values: 1 to 10. Defaults to 10.
+	// +optional
+	BatchSize int64 `json:"batchSize,omitempty" protobuf:"varint,16,opt,name=batchSize"`
 }
 
 // PubSubEventSource refers to event-source for GCP PubSub related events.

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -725,6 +725,10 @@ type SQSEventSource struct {
 	// SkipPollingWhenEventBusFull skips polling SQS when event bus is at capacity
 	// +optional
 	SkipPollingWhenEventBusFull bool `json:"skipPollingWhenEventBusFull,omitempty" protobuf:"varint,14,opt,name=skipPollingWhenEventBusFull"`
+	// EventBusFullWaitSeconds specifies the duration (in seconds) to wait before checking EventBus capacity again when it is full.
+	// The default value is 10 seconds.
+	// +optional
+	EventBusFullWaitSeconds int64 `json:"eventBusFullWaitSeconds,omitempty" protobuf:"varint,15,opt,name=eventBusFullWaitSeconds"`
 }
 
 // PubSubEventSource refers to event-source for GCP PubSub related events.


### PR DESCRIPTION
### Description

Implements capacity-based polling control for AWS SQS EventSource with backpressure handling to prevent message loss when the JetStream event bus is at capacity.

Added optional `skipPollingWhenEventBusFull` configuration that checks event bus capacity before each SQS poll. When enabled:
  - Event bus capacity is checked before polling SQS
  - If event bus is full, polling is skipped and messages remain in SQS
  - Polling automatically resumes when capacity becomes available

### Configuration

```
apiVersion: argoproj.io/v1alpha1
  kind: EventSource
  metadata:
    name: aws-sqs
  spec:
    sqs:
      example:
        queue: "my-queue"
        region: "us-west-2"
        accessKey:
          name: aws-secret
          key: accesskey
        secretKey:
          name: aws-secret
          key: secretkey
        waitTimeSeconds: 20

        # Skip polling SQS when event bus is at capacity
        # Recommended: true for production use with JetStream
        skipPollingWhenEventBusFull: true
```

### Backward Compatibility

  ✅ Fully backward compatible

  - The skipPollingWhenEventBusFull field is optional and defaults to false
  - Existing SQS EventSource configurations continue to work without any changes
  - No breaking changes to the API or existing behavior
  - When disabled (default), SQS polling behaves exactly as before
  - No migration required for existing deployments

  ###  Test Results

1. **Capacity Saturation Test**
  - Setup: Configure JetStream event bus with low MaxMsgs limit, enable skipPollingWhenEventBusFull: true
  - Expected: SQS polling stops when MaxMsgs reached, logs indicate capacity full
  - Verified: No SQS ReceiveMessage API calls while event bus is full
  ```
2025-10-27T16:59:21.719-07:00{"level":"info","ts":1761609561.7191703,"logger":"argo-events.eventsource","caller":"awssqs/start.go:94","msg":"EventBus at capacity - MaxMsgs limit reached","eventSourceName":"aip-test","eventSourceType":"sqs","eventName":"example","eventSource":"aip-test","eventName":"example","currentMsgs":1,"maxMsgs":1}
```

  2. **Capacity Recovery Test**
  - Setup: Fill event bus to capacity, then consume messages to free space
  - Expected: Polling automatically resumes, log shows "EventBus capacity available again, resuming SQS polling"
  - Verified: SQS messages are processed after capacity becomes available
  ```
{"level":"info","ts":1761611036.2187438,"logger":"argo-events.eventsource","caller":"awssqs/start.go:186","msg":"EventBus capacity available again, resuming SQS polling","eventSourceName":"aip-test","eventSourceType":"sqs","eventName":"example","eventSource":"aip-test","eventName":"example","wasFull":1460}
```

  3. **Message Integrity Test**
  - Setup: Saturate event bus, publish messages to SQS, wait for capacity to free
  - Expected: All SQS messages processed after capacity recovery, none moved to DLQ
  - Verified: Message count matches, no messages in DLQ (Attached below)

  4. **Backward Compatibility Test**
  - Setup: Existing SQS EventSource without skipPollingWhenEventBusFull field
  - Expected: SQS polling continues normally regardless of event bus capacity
  - Verified: Default behavior unchanged 

  5. **JetStream Unavailability Test**
  - Setup: Disconnect or crash JetStream, enable skipPollingWhenEventBusFull: true
  - Expected: SQS polling stops (fail-safe), logs show "JetStream context not available"
  - Verified: Messages remain in SQS, not lost (Attached below)

  6. **Extended Saturation Logging Test**
  - Setup: Keep event bus full for >10 minutes
  - Expected: Warning logs every 10 minutes with duration tracking
  - Verified: Log format: "EventBus has been full for extended period, duration: 10m0s"
  ```
2025-10-27T17:09:11.929-07:00{"level":"warn","ts":1761610151.9296772,"logger":"argo-events.eventsource","caller":"awssqs/start.go:169","msg":"EventBus has been full for extended period","eventSourceName":"aip-test","eventSourceType":"sqs","eventName":"example","eventSource":"aip-test","eventName":"example","duration":600,"consecutiveChecks":60}
```

<img width="1582" height="662" alt="Screenshot 2025-10-27 at 6 03 22 PM" src="https://github.com/user-attachments/assets/2128962d-3bdd-4648-815f-e8c60fe54536" />
<img width="1586" height="651" alt="Screenshot 2025-10-27 at 6 02 37 PM" src="https://github.com/user-attachments/assets/e2740622-f5cd-41f9-8037-352dd54dca6b" />

